### PR TITLE
fix:修复使用fetch发送请求时应用闪退

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
@@ -369,7 +369,7 @@ export default class ReactNativeBlobUtilReq {
 
   // 判断请求的数据是否是blob
   isBlobResponse(headers: Object, options: ConfigType) {
-    let cType: string = (headers['content-type'] || headers['Content-Type']).toLowerCase();
+    let cType: string = String((headers['content-type'] || headers['Content-Type']) ?? '').toLowerCase();
     let isText: boolean = cType.indexOf('text/') !== -1;
     let isJson: boolean = cType.indexOf('application/json') !== -1;
     let isCustomBinary: boolean = (options.binaryContentTypes?.length || 0) > 0;


### PR DESCRIPTION

# Summary

- closes #12 
- 修复使用fetch发送请求时应用闪退
- 参考Android和iOS的源码当响应头中没有`Content-Type`或者`content-type`字段时给默认值空字符串


## Test Plan

复现代码：  ReactNativeBlobUtil.config({
      timeout: 20000,
      indicator: true,
      })
      .fetch(
      "POST",
      url,//请求地址
      {
      "Content-Type": "image/jpg",
      },
      ReactNativeBlobUtil.wrap(”文件地址“)
      ).then(res=>console.log(res,"res")
      )
      .catch((e) => {
      console.log(">>>>>>>>>>>>>>>>>>>e:", e);
      });


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)


