### PR TITLE
fix:修复使用isDir方法返回undefined的问题

### DIFF
--- a/codegenSpecs/NativeBlobUtils.js
+++ b/codegenSpecs/NativeBlobUtils.js
@@ -33,7 +33,7 @@ export interface Spec extends TurboModule {
     +createFileASCII: (path: string, data: Array<any>) => Promise<void>;
     +pathForAppGroup: (groupName: string) => Promise<string>;
     +syncPathAppGroup: (groupName: string) => string;
-    +exists: (path: string, callback: (value: Array<boolean>) => void) => void;
+    +exists: (path: string, callback: (value:boolean,isDir?:boolean) => void) => void;
     +writeFile: (path: string, encoding: string, data: string, transformFile: boolean, append: boolean) => Promise<number>;
     +writeFileArray: (path: string, data: Array<any>, append: boolean) => Promise<number>;
     +writeStream: (path: string, withEncoding: string, appendData: boolean, callback: (value: Array<any>) => void) => void;

--- a/harmony/blobUtil/src/main/ets/BlobUtilTurboModule.ts
+++ b/harmony/blobUtil/src/main/ets/BlobUtilTurboModule.ts
@@ -94,7 +94,7 @@ export class BlobUtilTurboModule extends TurboModule {
     this.reactNativeBlobUtilImpl.writeArrayChunk(streamId,withArray,callback)
   }
 
-  exists(path: string, callback: (value: boolean) => void){
+  exists(path: string, callback: (value: boolean,isDir?:boolean) => void){
     this.reactNativeBlobUtilImpl.exists(path,callback)
   }
 

--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -246,15 +246,21 @@ export default class ReactNativeBlobUtilFS {
     })
   }
 
-  exists(path: string, callback: (value: boolean) => void) {
+  exists(path: string, callback: (value: boolean, isDir?: boolean) => void) {
     return new Promise((resolve, reject) => {
-      fs.access(path, (err: BusinessError, result: boolean) => {
+      fs.stat(path, (err: BusinessError, res: fs.Stat) => {
         if (err) {
           reject('File does not exist');
         } else {
-          callback(result);
+          fs.access(path, (err: BusinessError, result: boolean) => {
+            if (err) {
+              reject('File does not exist');
+            } else {
+              callback(result, res.isDirectory());
+            }
+          });
         }
-      });
+      })
     })
   };
 

--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilImpl.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilImpl.ts
@@ -109,7 +109,7 @@ export default class ReactNativeBlobUtilImpl {
     this.reactNativeBlobUtilStream.writeArrayChunk(streamId, withArray, callback)
   }
 
-  exists(path: string, callback: (value: boolean) => void) {
+  exists(path: string, callback: (value: boolean,isDir?:boolean) => void) {
     this.reactNativeBlobUtilFS.exists(path, callback)
   }
 


### PR DESCRIPTION

# Summary

- closes #15 
- 修复使用isDir方法返回undefined的问题
- 使用Harmony OS中的fs模块实现


## Test Plan
复现代码：
``` js
 ReactNativeBlobUtil.fs.isDir("目录地址").then(res => {
       console.log("result", res)
    }).catch(res => console.log("err", res)
    )
```

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

