### PR TITLE
fix:修复readFile读取文件以base64的编码格式返回应用闪退(no codegen版本)

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -350,7 +350,7 @@ export default class ReactNativeBlobUtilFS {
             let bytes = buffer.from(buf, 0, readLen);
             switch (encoding.toLowerCase()) {
               case "base64":
-                resolve(buffer.transcode(bytes, 'utf-8', 'base64'));
+                resolve(bytes.toString("base64"));
                 break;
               case "ascii":
                 resolve(buffer.transcode(bytes, 'utf-8', 'ascii'));


### PR DESCRIPTION

# Summary
- close #18 
- 使用readFile读取文件并且以base64的形式返回会应用闪退
- 之前的实现方案是使用buffer.buffer.transcode()从utf-8转为base64的编码格式，返回新的buffer对象，通过对比Android，和iOS的实现源码，使用buffer.toString("base64")实现，返回的为base64编码格式的字符串

## Test Plan
 复现代码
```` js
ReactNativeBlobUtil.fs.readFile(文件地址, "base64")
````
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
