### PR TITLE
fix:修复使用writeFile 写入中文汉字乱码问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -147,8 +147,7 @@ export default class ReactNativeBlobUtilFS {
     return new Promise((resolve,reject) => {
       try {
         let file = fs.openSync(path, fs.OpenMode.READ_WRITE | fs.OpenMode.CREATE);
-        let encod =buffer.transcode(buffer.from(data), 'utf-8', 'ascii')
-        let writeLen = fs.writeSync(file.fd,encod.buffer);
+        let writeLen = fs.writeSync(file.fd,data);
         if(writeLen==-1){
           console.log("write data to file succeed and size is:" + writeLen)
         }else{


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- closes #21 
- 修复使用writeFile 写入中文汉字写入的中文汉字乱码问题
-使用@ohos.file.fs  的writeSync 可以直接写入字符串

## Test Plan
````js
  const writeFile = async () => {

    ReactNativeBlobUtil.fs.writeFile(
      text + "/test.txt",
      "abcAbc123@#￥打不拆",
      "utf8"
    ).then(res => setState(true))
  }
````


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

