### PR TITLE
fix:修复readFile方法读取文件以ascii码返回结果是buffer而不是数组的问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -354,13 +354,16 @@ export default class ReactNativeBlobUtilFS {
           } else {
             let bytes = buffer.from(buf, 0, readLen);
             switch (encoding.toLowerCase()) {
-              case "base64":
+              case 'base64':
                 resolve(bytes.toString('base64'));
                 break;
-              case "ascii":
-                resolve(buffer.transcode(bytes, 'utf-8', 'ascii'));
+              case 'ascii': {
+                let ascUInt8Array: Uint8Array = new Uint8Array(bytes.buffer);
+                let ascArr = Array.from(ascUInt8Array);
+                resolve(ascArr);
                 break;
-              case "utf8":
+              }
+              case 'utf8':
                 resolve(bytes.toString('utf-8'));
                 break;
               default:


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- closes #23 
- readFile方法读取文件以ascii码返回,返回结果为ascii的数组
- 使用Uint8Array转化，在使用Array.from()转化为数组
-更改了readFile以ascii编码返回读取结果

## Test Plan
````js
 const readFile = async () => {
    ReactNativeBlobUtil.fs.readFile(text + "/test.txt", "ascii").then(res => {
        console.log(res)
    }
    )
  }
`````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

