### PR TITLE
fix:修复writeStream方法在流式写入时写入内容替换了原本内容问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilStream.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilStream.ts
@@ -46,7 +46,7 @@ export default class ReactNativeBlobUtilStream {
     let file = fs.openSync(filePath);
     this.encoding = encoding;
     try {
-      let stream = await fs.createStreamSync(filePath, "r+")
+      let stream = await fs.createStreamSync(filePath, "a+")
       let uuid = util.generateRandomUUID(true);
       ReactNativeBlobUtilStream.fileStreams.set(uuid, {
         stream: stream,


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
- closes #25  
- 修复writeStream方法在流式写入时写入内容替换了原本内容
- fs.createStreamSync(filePath, mode) 当mode为”a+“时  a+：以附加方式打开可读写的文件。若文件不存在，则会建立该文件，如果文件存在，写入的数据会被加到文件尾后，即文件原先的内容会被保留。

## Test Plan
````js
  const writeStream = () => {

    ReactNativeBlobUtil.fs.writeStream(
      text + "/test.txt",
      'utf8',
      true
    )
    .then((ofstream) => {
      ofstream.write('foo')
      ofstream.write('bar')
      return ofstream.close()
     
  })
)
````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)


