### PR TITLE
fix:修复appendFile追加文件会替换文件原有内容问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -146,7 +146,11 @@ export default class ReactNativeBlobUtilFS {
   writeFile(path: string,encoding: string,data: string ,transformFile: boolean, append: boolean):Promise<number> {
     return new Promise((resolve,reject) => {
       try {
+        let accessRes = fs.accessSync(path);
         let file = fs.openSync(path, fs.OpenMode.READ_WRITE | fs.OpenMode.CREATE);
+        if (append && accessRes) {
+          file = fs.openSync(path, fs.OpenMode.READ_WRITE | fs.OpenMode.APPEND);
+        }
         let writeLen = fs.writeSync(file.fd,data);
         if(writeLen==-1){
           console.log("write data to file succeed and size is:" + writeLen)


### PR DESCRIPTION

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- closes #27 
- 修复appendFile追加文件会替换文件原有内容
- wirteFile当append属性为true是并且文件存在时设置设置为往后追加文件fs.openSync(path,openMode)设置openMode为fs.OpenMode.APPEND


## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。

````js
 ReactNativeBlobUtil.fs.appendFile(
      text + "/test.txt",
      "追加数据",
      "utf8"
    )
````
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

