### PR TITLE
fix:修复fetch().progress(callback)方法会一直调用callback()问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
@@ -326,6 +326,9 @@ export default class ReactNativeBlobUtilReq {
         this.sendDownloadProgress();
       }
       if (count === -1) {
+        if (this.downloadTimer) {
+          clearInterval(this.downloadTimer);
+        }
         this.downloadTimer = setInterval(() => {
           if (!this.downloadInfo?.totalSize) return;
           this.sendDownloadProgress();


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary


- closes #26 
- 修复fetch().progress(callback)方法会一直调用callback()
- 引起这个问题是因为在监听httpRequest.on('dataSendProgress'）时会多次调用，创建多个定时器，而在清理定时器的时候只清理了最后一个定时器，导致还有定时器在运行，实现方案就是在调用时判断有没有定时器如果有就清楚上一个定时器保证只有一个定时器运行


## Test Plan
````js
 const fetchprogress = (setState: ArgState) => {
    let task = ReactNativeBlobUtil.config({
      fileCache: true
    })
      .fetch('GET', "http://172.26.224.1:3006/download") .progress({count:-1,interval:1000},(received, total) => {
        console.log('progress ' + Math.floor(received/total*100) + '%')
    })
     
  }
````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

