### PR TITLE
fix:修复使用fetch请求传输json数据报错的问题

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilReq.ts
@@ -292,7 +292,7 @@ export default class ReactNativeBlobUtilReq {
   }
 
   isPathStr(str: string): boolean {
-    return !!(str.indexOf(FILE_PREFIX) || str.indexOf(CONTENT_PREFIX) || str.indexOf('/') === 0);
+    return !!(str.startsWith(FILE_PREFIX) || str.startsWith(CONTENT_PREFIX) || str.indexOf('/') === 0);
   }
 
   getABData(isPath: boolean, data: string): ArrayBuffer {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- closes #34 
- :修复使用fetch请求传输json数据报错`getABData fail，check file is exists`
- 在判断传输的数据是否为地址时不使用indexof使用startsWith返回Boolean值


## Test Plan

复现代码
````js
 const response = await RNFetchBlob.config({
      // Add this line to ensure the response will be treated as binary data
      fileCache: false,
    }).fetch(
      'POST',
      global.URL_XUNJI + uri,
      {
        'Content-Type': 'application/json',
        'Accept-Encoding': 'gzip',
        Authorization: `Bearer ${global.token}`,
      },
      JSON.stringify(body),
    );
````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)

