### PR TITLE
fix:修复使用exists()检测文件是否存在是当文件不存在时没有返回值

### DIFF
--- a/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
+++ b/harmony/blobUtil/src/main/ets/ReactNativeBlobUtil/ReactNativeBlobUtilFS.ts
@@ -253,6 +253,7 @@ export default class ReactNativeBlobUtilFS {
     return new Promise((resolve, reject) => {
       fs.stat(path, (err: BusinessError, res: fs.Stat) => {
         if (err) {
+          callback(false, false);
           reject('File does not exist');
         } else {
           fs.access(path, (err: BusinessError, result: boolean) => {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- closes #39 
- 修复使用exists()检测文件是否存在是当文件不存在时没有返回值
- 更改了exists方法在检查文件路径不存在时返回false

Explain the **motivation** for making this change: here are some points to help you:

- What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
- What is the feature? (if applicable)
- How did you implement the solution?
- What areas of the library does it impact?

## Test Plan

```js
 ReactNativeBlobUtil.fs.exists(text + dir).then(res => {
        setExistRes(JSON.stringify(res))
      if (res) {
        setState(true)
      }
    })
````

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)


